### PR TITLE
Fix typo in x-displayName tag of team_member_model

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -59,7 +59,7 @@ tags:
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/User" />
   - name: team_member_model
-    x-displayname: Team Member Model
+    x-displayName: Team Member Model
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/TeamMember" />
 


### PR DESCRIPTION
Fixes a small typo which was causing the generated docs to be using a fallback name instead of the correct one.