### PR TITLE
openapi: Tag schemas should be regular objects

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1226,7 +1226,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CategoryTag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/CategoryTag"
   /tag/loader:
     get:
       summary: Get a list of loaders
@@ -1240,7 +1242,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LoaderTag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/LoaderTag"
   /tag/game_version:
     get:
       summary: Get a list of game versions
@@ -1254,7 +1258,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GameVersionTag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/GameVersionTag"
   /tag/license:
     get:
       summary: Get a list of licenses
@@ -1268,7 +1274,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LicenseTag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/LicenseTag"
   /tag/donation_platform:
     get:
       summary: Get a list of donation platforms
@@ -1282,7 +1290,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DonationPlatformTag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/DonationPlatformTag"
   /tag/report_type:
     get:
       summary: Get a list of report types
@@ -2171,109 +2181,99 @@ components:
         - accepted
     # Tags
     CategoryTag:
-      type: array
-      items:
-        type: object
-        properties:
-          icon:
-            type: string
-            description: The SVG icon of a category
-            example: "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><polygon points=\"16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76\"/></svg>"
-          name:
-            type: string
-            description: The name of the category
-            example: "adventure"
-          project_type:
-            type: string
-            description: The project type this category is applicable to
-            example: mod
-        required:
-          - icon
-          - name
-          - project_type
+      type: object
+      properties:
+        icon:
+          type: string
+          description: The SVG icon of a category
+          example: "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\"/><polygon points=\"16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76\"/></svg>"
+        name:
+          type: string
+          description: The name of the category
+          example: "adventure"
+        project_type:
+          type: string
+          description: The project type this category is applicable to
+          example: mod
+      required:
+        - icon
+        - name
+        - project_type
     LoaderTag:
-      type: array
-      items:
-        type: object
-        properties:
-          icon:
+      type: object
+      properties:
+        icon:
+          type: string
+          description: The SVG icon of a loader
+          example: "<svg viewBox=\"0 0 276 288\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"23\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><g transform=\"matrix(1,0,0,1,-3302.43,-67.3276)\"><g transform=\"matrix(0.564163,0,0,1.70346,1629.87,0)\"><g transform=\"matrix(1.97801,-0.0501803,0.151517,0.655089,1678.7,-354.14)\"><g><path d=\"M820.011,761.092C798.277,738.875 754.809,694.442 734.36,673.389C729.774,668.668 723.992,663.75 708.535,674.369C688.629,688.043 700.073,696.251 703.288,699.785C711.508,708.824 787.411,788.803 800.523,803.818C802.95,806.597 780.243,781.318 793.957,764.065C799.444,757.163 811.985,752.043 820.011,761.092C826.534,768.447 830.658,779.178 816.559,790.826C791.91,811.191 714.618,873.211 689.659,893.792C677.105,904.144 661.053,896.143 653.827,887.719C646.269,878.908 623.211,853.212 602.539,829.646C596.999,823.332 598.393,810.031 604.753,804.545C639.873,774.253 696.704,730.787 716.673,713.831\"/></g></g></g></g></svg>"
+        name:
+          type: string
+          description: The name of the loader
+          example: fabric
+        supported_project_types:
+          type: array
+          items:
             type: string
-            description: The SVG icon of a loader
-            example: "<svg viewBox=\"0 0 276 288\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"23\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><g transform=\"matrix(1,0,0,1,-3302.43,-67.3276)\"><g transform=\"matrix(0.564163,0,0,1.70346,1629.87,0)\"><g transform=\"matrix(1.97801,-0.0501803,0.151517,0.655089,1678.7,-354.14)\"><g><path d=\"M820.011,761.092C798.277,738.875 754.809,694.442 734.36,673.389C729.774,668.668 723.992,663.75 708.535,674.369C688.629,688.043 700.073,696.251 703.288,699.785C711.508,708.824 787.411,788.803 800.523,803.818C802.95,806.597 780.243,781.318 793.957,764.065C799.444,757.163 811.985,752.043 820.011,761.092C826.534,768.447 830.658,779.178 816.559,790.826C791.91,811.191 714.618,873.211 689.659,893.792C677.105,904.144 661.053,896.143 653.827,887.719C646.269,878.908 623.211,853.212 602.539,829.646C596.999,823.332 598.393,810.031 604.753,804.545C639.873,774.253 696.704,730.787 716.673,713.831\"/></g></g></g></g></svg>"
-          name:
-            type: string
-            description: The name of the loader
-            example: fabric
-          supported_project_types:
-            type: array
-            items:
-              type: string
-              description: The project type
-            description: The project types that this loader is applicable to
-            example: [mod, modpack]
-        required:
-          - icon
-          - name
-          - supported_project_types
+            description: The project type
+          description: The project types that this loader is applicable to
+          example: [mod, modpack]
+      required:
+        - icon
+        - name
+        - supported_project_types
     GameVersionTag:
-      type: array
-      items:
-        type: object
-        properties:
-          version:
-            type: string
-            description: The name/number of the game version
-            example: 1.18.1
-          version_type:
-            type: string
-            enum: [release, snapshot, alpha, beta]
-            description: The type of the game version
-            example: release
-          date:
-            type: string
-            format: date-time
-            description: The date of the game version release
-          major:
-            type: boolean
-            description: Whether or not this is a major version, used for Featured Versions
-            example: true
-        required:
-          - version
-          - version_type
-          - date
-          - major
+      type: object
+      properties:
+        version:
+          type: string
+          description: The name/number of the game version
+          example: 1.18.1
+        version_type:
+          type: string
+          enum: [release, snapshot, alpha, beta]
+          description: The type of the game version
+          example: release
+        date:
+          type: string
+          format: date-time
+          description: The date of the game version release
+        major:
+          type: boolean
+          description: Whether or not this is a major version, used for Featured Versions
+          example: true
+      required:
+        - version
+        - version_type
+        - date
+        - major
     LicenseTag:
-      type: array
-      items:
-        type: object
-        properties:
-          short:
-            type: string
-            description: The short identifier of the license
-            example: lgpl-3
-          name:
-            type: string
-            description: The full name of the license
-            example: GNU Lesser General Public License v3
-        required:
-          - short
-          - name
+      type: object
+      properties:
+        short:
+          type: string
+          description: The short identifier of the license
+          example: lgpl-3
+        name:
+          type: string
+          description: The full name of the license
+          example: GNU Lesser General Public License v3
+      required:
+        - short
+        - name
     DonationPlatformTag:
-      type: array
-      items:
-        type: object
-        properties:
-          short:
-            type: string
-            description: The short identifier of the donation platform
-            example: bmac
-          name:
-            type: string
-            description: The full name of the donation platform
-            example: Buy Me a Coffee
-        required:
-          - short
-          - name
+      type: object
+      properties:
+        short:
+          type: string
+          description: The short identifier of the donation platform
+          example: bmac
+        name:
+          type: string
+          description: The full name of the donation platform
+          example: Buy Me a Coffee
+      required:
+        - short
+        - name
     # Errors
     InvalidInputError:
       type: object


### PR DESCRIPTION
In the schema definition, tags should be regular objects to allow projects consuming the OpenAPI scheme to generate sensible code.

The fact that tag routes return an array of tags should only be defined for their response, not in the tag schema itself.