### PR TITLE
openapi: Clarify what is hashed in a file

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -634,13 +634,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NotFoundError"
       parameters:
-        - in: path
-          name: hash
-          required: true
-          schema:
-            type: string
-            example: 619e250c133106bacc3e3b560839bd4b324dfda8
-          description: The hash of the file to query
+        - $ref: "#/components/parameters/FileHashIdentifier"
         - $ref: "#/components/parameters/AlgorithmIdentifier"
     delete:
       summary: Delete a file from its hash
@@ -663,13 +657,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NotFoundError"
       parameters:
-        - in: path
-          name: hash
-          required: true
-          schema:
-            type: string
-            example: 619e250c133106bacc3e3b560839bd4b324dfda8
-          description: The hash of the file to delete
+        - $ref: "#/components/parameters/FileHashIdentifier"
         - $ref: "#/components/parameters/AlgorithmIdentifier"
   /version_file/{hash}/update?algorithm={algorithm}:
     post:
@@ -678,13 +666,7 @@ paths:
       tags:
         - versions
       parameters:
-        - in: path
-          name: hash
-          required: true
-          schema:
-            type: string
-            example: 619e250c133106bacc3e3b560839bd4b324dfda8
-          description: The hash to find the latest version of
+        - $ref: "#/components/parameters/FileHashIdentifier"
         - $ref: "#/components/parameters/AlgorithmIdentifier"
       requestBody:
         description: Parameters of the updated version requested
@@ -1420,6 +1402,14 @@ components:
         enum: [sha1, sha512]
         example: sha512
         default: sha1
+    FileHashIdentifier:
+      name: hash
+      in: path
+      required: true
+      description: The hash of the file, considering its byte content, and encoded in hexadecimal
+      schema:
+        type: string
+        example: 619e250c133106bacc3e3b560839bd4b324dfda8
 
   schemas:
     # Project


### PR DESCRIPTION
Currently, it's a bit confusing what should be used in order to generate the hash of a file, especially whether one should hash the file name, or the file's contents. This seems obvious once you know which one to use, but for someone from outside, this can generate quite a headache.

This PR aims to clarify a bit how to generate the hash, given a file, so that hopefully people will not have the same problems I once had :slightly_smiling_face: 