### PR TITLE
Add rustls to sqlx install features

### DIFF
--- a/docs/details/contributing.md
+++ b/docs/details/contributing.md
@@ -38,7 +38,7 @@ If you wish to contribute code to a specific project, here's the place to start.
 Now, you'll have to install the sqlx CLI, which can be done with cargo:
 
 ```bash
-cargo install --git https://github.com/launchbadge/sqlx sqlx-cli --no-default-features --features postgres
+cargo install --git https://github.com/launchbadge/sqlx sqlx-cli --no-default-features --features postgres,rustls
 ```
 
 From there, you can create the database and perform all database migrations with these two commands:


### PR DESCRIPTION
The sqlx-cli install will fail if `rustls` or `native-tls` is omitted, I chose `rustls` but either would work.