### PR TITLE
Change custom emoji in role menu

### DIFF
--- a/static/welcome-channel.yaml
+++ b/static/welcome-channel.yaml
@@ -55,7 +55,7 @@
   roles:
     992998518602076170:
       description: Get notified when we make changes to the [Modrinth API](https://docs.modrinth.com/api-spec).
-      emoji: "<:modrinth:947700040300892190>"
+      emoji: "<:modrinth:1040805511538421890>"
     992998585618681907:
       description: Get notified when there is scheduled downtime for Modrinth.
       emoji: 📉


### PR DESCRIPTION
It seems that Modrinth emoji has been updated.

This PR changes it to the new emoji ID, perhaps this will fix the role menu not working? Who knows <img src="https://cdn.discordapp.com/emojis/815857962341761045.gif" alt="modCheck Emoji" width="22px" align="center">