### PR TITLE
openapi: Add responses to patchProjects

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1511,6 +1511,21 @@ paths:
                   description: An optional invite link to the projects' discord
                   example: https://discord.gg/AaBbCcDd
                   nullable: true
+      responses:
+        "204":
+          description: Projects successfully updated
+        "400":
+          description: One of the requested projects was not found
+          content:
+            application/json:
+              schema: *InvalidInputError
+        "401":
+          description: No authorization to edit one of the requested projects
+          content:
+            application/json:
+              schema: *AuthError
+        "404":
+          description: One of the requested projects is hidden
   /projects_random:
     get:
       summary: Get a list of random projects

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1524,8 +1524,6 @@ paths:
           content:
             application/json:
               schema: *AuthError
-        "404":
-          description: One of the requested projects is hidden
   /projects_random:
     get:
       summary: Get a list of random projects


### PR DESCRIPTION
This pr adds the missing responses to the **patch** request on `/projects` that is used to edit multiple projects.

In [projects.rs#L1228 ](https://github.com/modrinth/labrinth/blob/master/src/routes/v2/projects.rs#L1228) I have seen that this can be returned:
- **204 (no content)** if successful
- **400 (invalid request)** if one of the requested projects was not found
- **401 (unauthorized)** if the user does not have permission to bulk edit this project or if the user is not a member of the project
- **404 (not found)** if the project status is hidden