### PR TITLE
openapi: use contentMediaType to define type for image / icon upload

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1609,9 +1609,7 @@ paths:
             schema:
               type: string
               format: binary
-            encoding:
-              image:
-                contentType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
+              contentMediaType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
       security:
         - TokenAuth: []
       responses:
@@ -1711,9 +1709,7 @@ paths:
             schema:
               type: string
               format: binary
-            encoding:
-              image:
-                contentType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
+              contentMediaType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
       responses:
         "204":
           description: Gallery image successfully created
@@ -2427,13 +2423,11 @@ paths:
         - *UserIdentifier
       requestBody:
         content:
-          multipart/form-data:
+          image/*:
             schema:
-              enum:
-                - { }
-            encoding:
-              icon:
-                contentType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
+              type: string
+              format: binary
+              contentMediaType: image/png, image/jpeg, image/bmp, image/gif, image/webp, image/svg, image/svgz, image/rgb
       security:
         - TokenAuth: []
       responses:


### PR DESCRIPTION
This pr replaces `encoding`, `image`, `contentType` with `contentMediaType`. 
From what I read in the OpenAPI specification for version 3.1.0, this seems to be the correct property. See [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#considerations-for-file-uploads) for more info.

Also: I get an error when I run the openapi-generator to generate code with the current openapi file:
`attribute paths.'/project/{id|slug}/gallery'(post).requestBody.content.'image/*'.encoding.image is unexpected`
<details>
<summary>Steps to reproduce</summary>

- Download the latest openapi-generator from [here](https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-cli/6.5.0-SNAPSHOT/) ([source on GitHub](https://github.com/OpenAPITools/openapi-generator#1---installation))
- Download the latest openapi.yaml
- Run the generator on the openapi.yaml (example command: `java -ea -server -jar ~/openapi-generator-cli.jar generate -i ~/openapi.yaml -g php -o ~/apiclient`
- See the output
```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 5, Warning count: 27
Errors: 
	-attribute paths.'/project/{id|slug}/gallery'(post).requestBody.content.'image/*'.encoding.image is unexpected
	-attribute paths.'/project/{id|slug}/icon'(patch).requestBody.content.'image/*'.encoding.image is unexpected
	-paths.'/team/{team_id}/members/{user_id}'. Declared path parameter user_id needs to be defined as a path parameter in path or operation level
	-paths.'/team/{team_id}/members/{user_id}'. Declared path parameter team_id needs to be defined as a path parameter in path or operation level
	-attribute paths.'/user/{id|username}/icon'(patch).requestBody.content.'multipart/form-data'.encoding.icon is unexpected
Warnings: 
	-attribute paths.'/project/{id|slug}/gallery'(post).requestBody.content.'image/*'.encoding.image is unexpected
	-attribute paths.'/project/{id|slug}/icon'(patch).requestBody.content.'image/*'.encoding.image is unexpected
	-paths.'/team/{team_id}/members/{user_id}'. Declared path parameter user_id needs to be defined as a path parameter in path or operation level
	-paths.'/team/{team_id}/members/{user_id}'. Declared path parameter team_id needs to be defined as a path parameter in path or operation level
	-attribute paths.'/user/{id|username}/icon'(patch).requestBody.content.'multipart/form-data'.encoding.icon is unexpected

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:620)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:647)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:479)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)

```
</details>



Also this pr unifies `/project/{id|slug}/icon` and `/project/{id|slug}/gallery` with `/user/{id|username}/icon`, as all 3 take the image directly from the request body and read the binary payload (see [users.rs#L495](https://github.com/modrinth/labrinth/blob/master/src/routes/v2/users.rs#L495) )