### PR TITLE
Link to itzg/minecraft-server modpack support

### DIFF
--- a/docs/modpacks/playing_modpacks.md
+++ b/docs/modpacks/playing_modpacks.md
@@ -9,7 +9,8 @@ Please see the guide for [creating modpacks](creating_modpacks.md).
 ## How do I play a modpack?
 
 Currently, the easiest ways to play a Modrinth modpack are via [ATLauncher](https://atlauncher.com), [BakaXL](https://www.bakaxl.com/), [MultiMC](https://multimc.org), or [Prism Launcher](https://prismlauncher.org).
-To install a modpack server, try [mrpack-install](https://github.com/nothub/mrpack-install) or if using Docker, modpack support is included with [the `itzg/minecraft-server` image](https://github.com/itzg/docker-minecraft-server).
+
+To install a modpack on the server-side, try [mrpack-install](https://github.com/nothub/mrpack-install) or [the `itzg/minecraft-server` image](https://github.com/itzg/docker-minecraft-server) if using Docker.
 
 ### ATLauncher
 

--- a/docs/modpacks/playing_modpacks.md
+++ b/docs/modpacks/playing_modpacks.md
@@ -9,7 +9,7 @@ Please see the guide for [creating modpacks](creating_modpacks.md).
 ## How do I play a modpack?
 
 Currently, the easiest ways to play a Modrinth modpack are via [ATLauncher](https://atlauncher.com), [BakaXL](https://www.bakaxl.com/), [MultiMC](https://multimc.org), or [Prism Launcher](https://prismlauncher.org).
-To install a modpack server, try [mrpack-install](https://github.com/nothub/mrpack-install).
+To install a modpack server, try [mrpack-install](https://github.com/nothub/mrpack-install) or if using Docker, modpack support is included with [the `itzg/minecraft-server` image](https://github.com/itzg/docker-minecraft-server).
 
 ### ATLauncher
 


### PR DESCRIPTION
I was a afraid I might have been too intrusive on the existing sentence there, so I'm open to any suggestions. BTW, I linked to the repo rather than [the specific docs page](https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/modrinth-modpacks/), but let me know if that would be preferred.