### PR TITLE
mrpack format: add neoforge loader as valid dependency

### DIFF
--- a/docs/modpacks/format_definition.md
+++ b/docs/modpacks/format_definition.md
@@ -85,6 +85,7 @@ This object contains a list of IDs and version numbers that launchers will use i
 Available dependency IDs are:
 - `minecraft` - The Minecraft game
 - `forge` - The Minecraft Forge mod loader
+- `neoforge` - The NeoForge mod loader
 - `fabric-loader` - The Fabric loader
 - `quilt-loader` - The Quilt loader
 


### PR DESCRIPTION
While this is not mentioned anywhere else yet, I assume this should be a valid dependency ID in the future.
We are certainly going to support this in our upcoming Prism Launcher 8.0 release!
