### PR TITLE
Add missing ID property to Report schema

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1121,6 +1121,10 @@ components:
         - $ref: '#/components/schemas/CreatableReport'
         - type: object
           properties:
+            id:
+              type: string
+              description: The ID of the report
+              example: VVWWXXYY
             reporter:
               type: string
               description: The ID of the user who reported the item


### PR DESCRIPTION
It seems like someone forgot to add the ID property to the report schema