### PR TITLE
Update support channel links

### DIFF
--- a/static/support-channel.yaml
+++ b/static/support-channel.yaml
@@ -28,7 +28,7 @@
         - name: "<:paper:1049793355598540810> Paper"
           value: "[/papermc](https://discord.gg/papermc)"
           inline: true
-        - name: "<:purpur:1049793357351751772> Purpur"
+        - name: "<:purpur:1140436034505674762> Purpur"
           value: "[/mtAAnkk](https://discord.gg/mtAAnkk)"
           inline: true
         - name: "<:quilt:1049793857681887342> Quilt"

--- a/static/support-channel.yaml
+++ b/static/support-channel.yaml
@@ -22,6 +22,9 @@
         - name: "<:forge:1049793350498275358> Forge"
           value: "[/UvedJ9m](https://discord.gg/UvedJ9m)"
           inline: true
+        - name: "<:neoforge:1140437823783190679> NeoForge"
+          value: "[/UvedJ9m](https://discord.gg/UvedJ9m)"
+          inline: true
         - name: "<:paper:1049793355598540810> Paper"
           value: "[/papermc](https://discord.gg/papermc)"
           inline: true


### PR DESCRIPTION
- <img src="https://cdn.discordapp.com/emojis/1140437823783190679.png?size=64" alt="Neoforge" height="18" align="center"> Added NeoForge link. It duplicates Forge one to prevent confusion among the users who may not yet aware of rebranding or forgot about it.
- <img src="https://cdn.discordapp.com/emojis/1140436034505674762.png?size=64" alt="Purpur" height="18" align="center"> Changed Purpur emoji ID. Previous emoji had unreadable colour in dark mode, so it was replaced with one that has better colour.