### PR TITLE
Expand on the ban in Russia app FAQ entry

### DIFF
--- a/docs/faq/app/russia.md
+++ b/docs/faq/app/russia.md
@@ -1,5 +1,0 @@
-# Why can't I access the Modrinth App from Russia? (Почему я не могу получить доступ к приложению Modrinth из России?)
-
-The Modrinth App is currently nonfunctional in Russia. For now, the solutions are to either use a VPN or [one of the other launchers supporting Modrinth](../../modpacks/play.md). We're sorry for the inconvenience and hope we'll be able to figure out how to work around that in the future.
-
-Приложение Modrinth в настоящее время не работает в России. На данный момент для решения проблемы необходимо использовать VPN или [один из других пусковых установок, поддерживающих Modrinth](../../modpacks/play.md). Мы приносим извинения за причиненные неудобства и надеемся, что в будущем нам удастся найти решение этой проблемы.

--- a/docs/faq/app/russia.mdx
+++ b/docs/faq/app/russia.mdx
@@ -1,0 +1,75 @@
+# Почему я не могу использовать приложение Modrinth в России?
+
+К сожалению, некоторые российские операторы связи не позволяют приложению Modrinth связаться с нашими серверами из-за блокировки сервиса защиты от DDoS аттак, что мы используем — Cloudflare. Пользователи этих операторов могут столкнуться с проблемами при запуске приложения Modrinth. Чаще всего, это сообщение «Unable to read launcher tags from any source» при запуске приложения.
+
+Если вы лично столкнулись с этой проблемой, вы можете использовать одно следующих из решений:
+
+- **Используйте VPN сервис при запуске приложения Modrinth**. Это позволит приложению Modrinth связаться с нашими серверами и загрузить необходимые данные для запуска игры. По российскому законодательству мы не можем рекомендовать вам отдельные сервисы для обхода блокировок, поэтому вам придётся найти подобный сервис самостоятельно.
+
+- **Используйте стороннее приложение запуска Minecraft**. Если у вас нет возможности или вам неудобно использовать VPN, вы можете использовать приложения запуска Minecraft с поддержкой Modrinth. Мы рекомендуем попробовать [Prism Launcher](https://prismlauncher.org) и [ATLauncher](https://atlauncher.com). К сожалению, мы не можем оказывать помощь с этими приложениями, однако вы можете попросить помощи у [нашего сообщества в Discord](https://discord.modrinth.com) или на отдельных ресурсах этих приложений.
+
+Мы приносим наши искренние извинения за предоставленные удобства и надеемся на скорейшее устранение проблемы.
+
+## Дополнительная справка по теме
+
+### За что заблокировали Modrinth?
+
+Мы используем Cloudflare — сервис защиты интернет ресурсов от DDoS аттак и прочих угроз. Чтобы предоставлять сервис огромному количеству своих пользователей, Cloudflare распределяет свой ограниченный набор IP адресов сразу на сотни, а порой тысячи сайтов одновременно. К сожалению, некоторые из этих сайтов могут размещать содержимое, которое незаконно в России (например, сайты-казино).
+
+В России работает орган надзора за интернет ресурсами, Роскомнадзор, который ведёт реестр заблокированных интернет ресурсов. Когда Роскомнадзору поручается заблокировать интернет ресурс, они вносят ссылки на незаконное содержимое в реестр. Если сайт применяет HTTPS шифрование, то вместо ссылки Роскомнадзор вносит в реестр доменное имя сайта и связанные с ним IP адресы.
+
+Сам Modrinth не заблокирован и мы надеемся что так будет и в будущем. Однако, выделенные нам Cloudflare IP внесены в реестр заблокированных ресурсов.
+
+### Modrinth открывается в моём браузере!
+
+Операторы в России используют систему глубокого анализа пакетов для более точной реализации блокировок. Так как Modrinth, как и многие другие сайты, применяет HTTPS шифрование, анализировать подобные пакеты намного сложнее, из-за чего системы анализа строят предположения на основе малейших характеристик. Мы полагаем, что пакеты нашего приложения отличаются от тех, что отправляют браузеры, что вызывает подозрения у некоторых из подобных систем, из-за чего они разрывают соединение.
+
+:::info
+Если вы знаете больше информации по этой теме и можете помочь нам с устранением проблемы, пожалуйста, [напишите нам на GitHub](https://github.com/modrinth/theseus/issues/858) или в [нашем сообществе Discord](https://discord.modrinth.com). Знание английского приветствуется, но не обязательно.
+:::
+
+### Мне нужно связаться с моим оператором?
+
+Нет. Вас вряд ли поймут в службе поддержки и, скорее всего, ваш оператор не станет исправлять эту проблему.
+
+---
+
+**English translation provided below.**
+
+# Why can't I access Modrinth app in Russia?
+
+Unfortunately, some of the Russian internet service providers (ISPs) prevent Modrinth app from connecting to its servers due to the ban of Cloudflare, a service that we use to defend against DDoS attacks. Users of those ISPs may experience problems when using Modrinth app. Most often this manifests as the ‘Unable to read launcher tags from any source’ error upon opening the app.
+
+If you experience these problems, try one of the following solutions:
+
+- **Use a VPN service when opening the Modrinth app**. This will allow Modrinth app to connect to its services and download data necessary to launch Minecraft. Due to Russian law, we cannot recommend any specific VPN service that allows bypassing the bans, so you'll have to find one on your own.
+
+- **Use a third-party Minecraft launcher**. If you cannot use a VPN or find it inconvenient, you may try one of the Minecraft launchers that support Modrinth. We recommend you try [Prism Launcher](https://prismlauncher.org) or [ATLauncher](https://atlauncher.com). Unfortunately, we cannot offer you support with these launchers, however [our Discord community](https://discord.modrinth.com) may be able to help you with those. Check out their dedicated support resources as well.
+
+We offer our sincere apologies for the inconvinience and hope for the speedy resolution of this issue.
+
+## Additional information about the topic
+
+### Why was Modrinth banned?
+
+We use Cloudflare, a service that protects internet services against DDoS attacks and other vulnerabilities. To offer their service to many of their users, Cloudflare allocate its limited pool of IP addresses to hundreds and sometimes thousands services at a time. Unfortunately, some of these services may host content illegal in Russia (e.g., casino websites).
+
+Russia has an institution dedicated to monitoring internet services, Roskomnadzor, that maintains a registry of prohibited internet resources. When Roskomnadzor is tasked to ban a resource, they add links to illegal content to the registry. If illegal site uses HTTPS encryption, instead of adding links, Roskomnadzor adds domain name and IP addresses associated with the site instead.
+
+Modrinth itself isn't banned in Russia and we hope it stays that way. However, IPs allocated to us by Cloudflare are in the registry of prohibited internet resources.
+
+### But Modrinth opens in my browser!
+
+ISPs in Russia use Deep packet inspection (DPI) in order to implement targetted bans. Because Modrinth is using HTTPS encryption like any other site, it's much harder to analyze such packets, so such systems have to rely on smallest details in their judgment. We suppose that packets from our app may look slightly different than ones coming from browsers, which makes those systems suspicious, and cause them to drop the connection.
+
+:::info
+If you have more information about this topic or can help us in solving the issue, please write us on GitHub or in [our Discord community](https://discord.modrinth.com). Fluency in English is appreciated, but not required.
+:::
+
+### Do I need to contact my ISP?
+
+No. You will probably be misunderstood by the customer support, and then your ISP may be unwilling to fix this issue.
+
+<head>
+  <html lang="ru" />
+</head>

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -43,7 +43,7 @@ pagination_next: roadmap
 - [Why did my instances suddenly disappear?](app/power-outage.md)
 - [Why am I getting an error from Fabric saying that it cannot access intermediary?](app/intermediary.md)
 - [Why can't I launch certain Minecraft versions?](app/unsupported.md)
-- [Why can't I access the Modrinth App from Russia?](app/russia.md)
+- [Why can't I access the Modrinth App from Russia?](app/russia.mdx)
 
 ### Account-related errors
 


### PR DESCRIPTION
- Brought Russian translation to the top. Russian translation is done by
  me so it may be pretty incorrect, but far better than machine
  translation that used to be there already.

- Expanded on the reasons why Modrinth was banned to explain that it
  wasn't the Modrinth that actually got banned, but Cloudflare IP
  addresses.

- Explained how these bans work for the curious.

- Referenced tracking GitHub issue and invited to Discord community
  where people can write us if they can help us with the ban.

- Change page language to Russian for better SEO. To be honest, English
  section must be wrapped into a big div with lang="en" tag, but this
  completely breaks markup. Too bad.
