### PR TITLE
openapi: Change schema for MultipleProjectIdentifier to string

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -102,9 +102,7 @@ components:
       name: ids
       description: The IDs of the projects
       schema:
-        type: array
-        items:
-          type: string
+        type: string
         example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
       required: true
     UserIdentifier:


### PR DESCRIPTION
The schema for the MultipleProjectIdentifier is currently defined as:

```yaml
schema:
  type: array
  items:
    type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```

this is wrong.
It would mean that my request to fetch multiple projects would look like this:
`https://api.modrinth.com/v2/projects?ids=wKkoqHrH&ids=Ojp3IEa8`
This does not work and returns this response:
```json
{
    "error": "invalid_input",
    "description": "Error while validating input: Query deserialize error: duplicate field `ids`"
}
```

This PR changes the schema for MultipleProjectIdentifier to string.
It is actually a string, written like an array in json.

New
 ```yaml
schema:
  type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```

And the request will look like this:
`https://api.modrinth.com/v2/projects?ids=%5B%22wKkoqHrH%22%2C%22EBqEP7Kk%22%5D`
Which is `'["wKkoqHrH","EBqEP7Kk"]'` but uri encoded.
