### PR TITLE
openapi: Change schema type for loaders and game_versions to string

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -2374,18 +2374,14 @@ paths:
           required: false
           description: "The types of loaders to filter for"
           schema:
-            type: array
-            items:
-              type: string
+            type: string
             example: "[\"fabric\"]"
         - in: query
           name: game_versions
           required: false
           description: "The game versions to filter for"
           schema:
-            type: array
-            items:
-              type: string
+            type: string
             example: "[\"1.18.1\"]"
         - in: query
           name: featured


### PR DESCRIPTION
The schema `loaders` and `game_versions` in the endpoint `/project/{id|slug}/version` are currently defined as:

```yaml
        - in: query
          name: loaders
          required: false
          description: The types of loaders to filter for
          schema:
            type: array
            items:
              type: string
            example: '["fabric"]'
        - in: query
          name: game_versions
          required: false
          description: The game versions to filter for
          schema:
            type: array
            items:
              type: string
            example: '["1.18.1"]'
```

this is wrong.
It would mean that my request to list project versions would look like this:
`https://api.modrinth.com/v2/project/Ojp3IEa8/version?loaders=paper&loaders=spigot&game_versions=1.20.1&game_versions=1.20.2`
This does not work and returns this response:
```json
{
  "error": "invalid_input",
  "description": "Error while validating input: Query deserialize error: duplicate field `loaders`"
}
```

This PR changes the schema type for `loaders` and `game_versions` to string.
It is actually a string, written like an array in json.

New
```yaml
        - in: query
          name: loaders
          required: false
          description: The types of loaders to filter for
          schema:
            type: string
            example: '["fabric"]'
        - in: query
          name: game_versions
          required: false
          description: The game versions to filter for
          schema:
            type: string
            example: '["1.18.1"]'
```

And the request will look like this:
`https://api.modrinth.com/v2/project/smithing-table-fix/version?loaders=["paper","spigot"]&game_versions=["1.20.1","1.20.2"]`


Related to https://github.com/modrinth/docs/pull/138