### PR TITLE
openapi: Change schema for notification ids to string

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -3069,9 +3069,7 @@ paths:
         name: ids
         description: The IDs of the notifications
         schema:
-          type: array
-          items:
-            type: string
+          type: string
           example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
         required: true
     get:


### PR DESCRIPTION
The schema for the notification IDs in `/notifications` is currently defined as:

```yaml
schema:
  type: array
  items:
    type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```
this is wrong.
It would mean that my request to fetch notifications would look like this:
`https://api.modrinth.com/v2/notifications?ids=vNcGR3Fd&ids=EBqEP7Kk`
This does not work and returns this response:
```json
{
  "error": "invalid_input",
  "description": "Error while validating input: Query deserialize error: duplicate field `ids`"
}
```

This PR changes the schema for the notification IDs to string.
It is actually a string, written like an array in json.

New
 ```yaml
schema:
  type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```

And the request will look like this:
`https://api.modrinth.com/v2/notifications?ids=["vNcGR3Fd", "EBqEP7Kk"]`


Related to:
 - https://github.com/modrinth/docs/pull/138
 - https://github.com/modrinth/docs/pull/139
 - https://github.com/modrinth/docs/pull/140