### PR TITLE
openapi: Change schema for version ids to string

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -2558,9 +2558,7 @@ paths:
         name: ids
         description: The IDs of the versions
         schema:
-          type: array
-          items:
-            type: string
+          type: string
           example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
         required: true
     get:


### PR DESCRIPTION
The schema for the version IDs in `/versions` is currently defined as:

```yaml
schema:
  type: array
  items:
    type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```
this is wrong.
It would mean that a request to fetch multiple versions would look like this:
`https://api.modrinth.com/v2/versions?ids=wKkoqHrH&ids=Ojp3IEa8`
This does not work and returns this response:
```json
{
    "error": "invalid_input",
    "description": "Error while validating input: Query deserialize error: duplicate field `ids`"
}
```

This PR changes the schema for the IDs to string.
It is actually a string, written like an array in json.

New
 ```yaml
schema:
  type: string
  example: "[\"AABBCCDD\", \"EEFFGGHH\"]"
```

And the request will look like this:
`https://api.modrinth.com/v2/versions?ids=["vNcGR3Fd", "EBqEP7Kk"]`


Related to:
 - https://github.com/modrinth/docs/pull/138
 - https://github.com/modrinth/docs/pull/139
 - https://github.com/modrinth/docs/pull/140
 - https://github.com/modrinth/docs/pull/141
 - https://github.com/modrinth/docs/pull/142
 - https://github.com/modrinth/docs/pull/143
 - https://github.com/modrinth/docs/pull/144