### PR TITLE
Add unkown to possible values for client_side and server_side field

### DIFF
--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -621,12 +621,12 @@ components:
           description: A list of the categories that the project has
         client_side:
           type: string
-          enum: [required, optional, unsupported]
+          enum: [required, optional, unsupported, unknown]
           description: The client side support of the project
           example: required
         server_side:
           type: string
-          enum: [required, optional, unsupported]
+          enum: [required, optional, unsupported, unknown]
           description: The server side support of the project
           example: optional
     # Fields added to search results and direct project lookups that cannot be edited.


### PR DESCRIPTION
Many Modrinth projects currently report their client/server compatibility to be "unknown".
While this [appears to be a bug](https://github.com/modrinth/labrinth/issues/879), it has existed for a long time and doesn't seem like it will be fixed any time soon.

In the meantime, this causes issues for projects using the OpenAPI spec because many generators throw errors if unexpected enum values are encountered.

I propose adding these values to the API specification to prevent these issues until the underlying issues are solved.

https://api.modrinth.com/v2/tag/side_type also returns "unknown" as a valid value.